### PR TITLE
chore: Puts sol source contracts into artifact published on npmjs

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,8 +6,6 @@ coverage.json
 allFiredEvents
 scTopics
 package-lock.json
-contracts
-!build/contracts
 migrations
 scripts
 test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@windingtree/lif-token",
-  "version": "0.1.0",
+  "version": "0.1.2-erc827",
   "description": "Winding Tree Platform Token",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is a temporary solution until #319 is resolved. It will allow us to simplify dependency management in wt-contracts for now.